### PR TITLE
feat: sniffer plants support 

### DIFF
--- a/src/main/java/org/finetree/fineharvest/Events.java
+++ b/src/main/java/org/finetree/fineharvest/Events.java
@@ -211,6 +211,20 @@ public class Events implements Listener  {
                     blk.getWorld().dropItemNaturally(blk.getLocation(), drops);
                 }
                 break;
+            case PITCHER_CROP:
+                drops.setType(Material.PITCHER_PLANT);
+                drops.setAmount(1);
+                if(drops.getAmount() > 0) {
+                    blk.getWorld().dropItemNaturally(blk.getLocation(), drops);
+                }
+                break;
+            case TORCHFLOWER_CROP:
+                drops.setType(Material.TORCHFLOWER);
+                drops.setAmount(1);
+                if(drops.getAmount() > 0) {
+                    blk.getWorld().dropItemNaturally(blk.getLocation(), drops);
+                }
+                break;
         }
     }
 

--- a/src/main/java/org/finetree/fineharvest/Events.java
+++ b/src/main/java/org/finetree/fineharvest/Events.java
@@ -66,7 +66,7 @@ public class Events implements Listener  {
 
         //Check the crop is ripe
         Ageable age = (Ageable) clickedBlock.getBlockData();
-        if(!isRipe(mat, age.getAge())) { return; }
+        if(!isSniffer(mat) && !isRipe(mat, age.getAge())) { return; }
 
         Sounds.popSound(clickedBlock, harvestVolume);
 
@@ -154,6 +154,13 @@ public class Events implements Listener  {
             case WHEAT, CARROTS, POTATOES -> age == 7;
             case BEETROOTS -> age == 3;
             case NETHER_WART -> age == 3;
+            default -> false;
+        };
+    }
+
+    private boolean isSniffer(Material material) {
+        return switch(material) {
+            case PITCHER_CROP, TORCHFLOWER_CROP -> true;
             default -> false;
         };
     }

--- a/src/main/java/org/finetree/fineharvest/Events.java
+++ b/src/main/java/org/finetree/fineharvest/Events.java
@@ -143,33 +143,19 @@ public class Events implements Listener  {
     }
 
     private boolean isCrop(Material material) {
-        switch (material) {
-            case WHEAT:
-            case CARROTS:
-            case POTATOES:
-            case BEETROOTS:
-            case NETHER_WART:
-            case TORCHFLOWER:
-            case PITCHER_PLANT:
-                return true;
-            default:
-                return false;
-        }
+        return switch (material) {
+            case WHEAT, CARROTS, POTATOES, BEETROOTS, NETHER_WART, TORCHFLOWER_CROP, PITCHER_CROP -> true;
+            default -> false;
+        };
     }
 
     private boolean isRipe(Material material, int age) {
-        switch (material) {
-            case WHEAT:
-            case CARROTS:
-            case POTATOES:
-                return age == 7;
-            case BEETROOTS:
-                return age == 3;
-            case NETHER_WART:
-                return age == 3;
-            default:
-                return false;
-        }
+        return switch (material) {
+            case WHEAT, CARROTS, POTATOES -> age == 7;
+            case BEETROOTS -> age == 3;
+            case NETHER_WART -> age == 3;
+            default -> false;
+        };
     }
 
     private void dropSeeds(Material mat, Block blk, ItemStack hoe) {

--- a/src/main/java/org/finetree/fineharvest/Events.java
+++ b/src/main/java/org/finetree/fineharvest/Events.java
@@ -149,6 +149,8 @@ public class Events implements Listener  {
             case POTATOES:
             case BEETROOTS:
             case NETHER_WART:
+            case TORCHFLOWER:
+            case PITCHER_PLANT:
                 return true;
             default:
                 return false;


### PR DESCRIPTION
Previously looks like sniffer plants weren't being checked for valid crops despite them being perfectly farmable on farmland blocks, and that the plugin was already using the 1.20 Spigot API, so I added support.

Referencing #6 and #9