### PR TITLE
Adjust AureliumSkills to AuraSkills & Add SuperiorSkyblock2 Protection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,13 +57,17 @@ repositories {
     maven {
         url = uri('https://repo.maven.apache.org/maven2/')
     }
+
+    maven {
+        url 'https://repo.bg-software.com/repository/api/'
+    }
 }
 
 dependencies {
     implementation 'com.github.Redempt:RedLib:6.5.2.1'
     compileOnly 'org.spigotmc:spigot-api:1.21.7-R0.1-SNAPSHOT'
     compileOnly 'com.gmail.nossr50.mcMMO:mcMMO:2.1.225' exclude group: 'commons-io'
-    compileOnly 'com.github.Archy-X:AureliumSkills:Beta1.3.23'
+    compileOnly 'dev.aurelium:auraskills-api-bukkit:2.2.4'
     compileOnly 'com.github.TechFortress:GriefPrevention:16.18'
     compileOnly 'com.github.TownyAdvanced:Towny:0.100.3.13'
     compileOnly 'com.github.angeschossen:LandsAPI:6.37.0'
@@ -73,6 +77,7 @@ dependencies {
     compileOnly 'com.intellectualsites.plotsquared:plotsquared-core'
     compileOnly 'com.griefdefender:api:2.1.0-SNAPSHOT'
     compileOnly 'net.essentialsx:EssentialsX:2.19.0'
+    compileOnly 'com.bgsoftware:SuperiorSkyblockAPI:2025.1'
 }
 
 java.sourceCompatibility = JavaVersion.VERSION_17

--- a/src/main/java/org/finetree/fineharvest/BuildCheck.java
+++ b/src/main/java/org/finetree/fineharvest/BuildCheck.java
@@ -10,6 +10,7 @@ import org.bukkit.plugin.Plugin;
 import org.finetree.fineharvest.protection.GriefDef;
 import org.finetree.fineharvest.protection.Plot2;
 import org.finetree.fineharvest.protection.ProtStones;
+import org.finetree.fineharvest.protection.SuperiorSkyblock2;
 
 import static org.finetree.fineharvest.FineHarvest.warnNoProtection;
 import static org.finetree.fineharvest.protection.EssentialsAB.canEssentialsAntiBuild;
@@ -41,6 +42,9 @@ public class BuildCheck {
         }
         if(hasPlugin("GriefDefender")){
             return GriefDef.canGriefDefender(ply, b);
+        }
+        if (hasPlugin("SuperiorSkyblock2")) {
+            return SuperiorSkyblock2.canSuperiorSkyblock2(ply, b);
         }
         /*if(hasPlugin("Residence")) {
             ResidencePlayer rPlayer = Residence.getInstance().getPlayerManager().getResidencePlayer(ply);

--- a/src/main/java/org/finetree/fineharvest/BuildCheck.java
+++ b/src/main/java/org/finetree/fineharvest/BuildCheck.java
@@ -44,7 +44,9 @@ public class BuildCheck {
             return GriefDef.canGriefDefender(ply, b);
         }
         if (hasPlugin("SuperiorSkyblock2")) {
-            return SuperiorSkyblock2.canSuperiorSkyblock2(ply, b);
+            if (SuperiorSkyblock2.canSuperiorSkyblock2(ply, b)) {//Skip SuperSkyblock2 check if no island, leave it up to WG global regions.
+                return true;
+            }
         }
         /*if(hasPlugin("Residence")) {
             ResidencePlayer rPlayer = Residence.getInstance().getPlayerManager().getResidencePlayer(ply);

--- a/src/main/java/org/finetree/fineharvest/Config.java
+++ b/src/main/java/org/finetree/fineharvest/Config.java
@@ -70,7 +70,7 @@ public class Config {
     @Comment("=======================")
 
     @Comment("")
-    @Comment("Enable AureliumSkills support?")
+    @Comment("Enable AureliumSkills/AuraSkills support?")
     @Comment("Default: true")
     public static boolean aureliumSkillsSupport = true;
 

--- a/src/main/java/org/finetree/fineharvest/Events.java
+++ b/src/main/java/org/finetree/fineharvest/Events.java
@@ -120,7 +120,7 @@ public class Events implements Listener  {
         }
 
         //API AureliumSkills Compat for Farming XP
-        if(aureliumSkillsSupport && skillMods.getOrDefault("AureliumSkills", false)){
+        if(aureliumSkillsSupport && skillMods.getOrDefault("AuraSkills", false)){
             AureliumSkills.aureliumAddXP(ply, mat);
         }
 
@@ -240,14 +240,14 @@ public class Events implements Listener  {
     public void plugEnable(PluginEnableEvent e) {
         Plugin plugin = e.getPlugin();
         switch( plugin.getDescription().getName() ){
-            case "AureliumSkills":
+            case "AuraSkills":
                 if(!aureliumSkillsSupport){ break; }
-                skillMods.put( "AureliumSkills", true );
+                skillMods.put( "AuraSkills", true );
                 plugin.getServer().getConsoleSender().sendMessage( tag
-                        + ChatColor.GREEN + "AureliumSkills support enabled"
-                        + ChatColor.RESET + " - Reloading Aurelium XP Values." );
-                File file = new File("plugins/AureliumSkills/sources_config.yml");
-                FineHarvest.AureliumSources = YamlConfiguration.loadConfiguration(file);
+                        + ChatColor.GREEN + "AuraSkills support enabled"
+                        + ChatColor.RESET + " - Reloading AuraSkills XP Values." );
+                File file = new File("plugins/AuraSkills/sources/farming.yml");
+                FineHarvest.AuraSources = YamlConfiguration.loadConfiguration(file);
                 break;
             case "mcMMO":
                 if(!mcMMOSupport){ break; }
@@ -261,11 +261,11 @@ public class Events implements Listener  {
     public void plugDisable(PluginDisableEvent e) {
         Plugin plugin = e.getPlugin();
         switch( plugin.getDescription().getName() ){
-            case "AureliumSkills":
+            case "AuraSkills":
                 if(!aureliumSkillsSupport){ break; }
-                skillMods.put( "AureliumSkills", false );
+                skillMods.put( "AuraSkills", false );
                 plugin.getServer().getConsoleSender().sendMessage( tag
-                        + ChatColor.RED + "AureliumSkills support disabled" );
+                        + ChatColor.RED + "AuraSkills support disabled" );
                 break;
             case "mcMMO":
                 if(!mcMMOSupport){ break; }

--- a/src/main/java/org/finetree/fineharvest/FineHarvest.java
+++ b/src/main/java/org/finetree/fineharvest/FineHarvest.java
@@ -9,21 +9,20 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.finetree.fineharvest.Config.aureliumSkillsSupport;
-import static org.finetree.fineharvest.Config.mcMMOSupport;
+import static org.finetree.fineharvest.Config.*;
 import static org.finetree.fineharvest.UpdateChecker.isVersionGreater;
 
 public final class FineHarvest extends JavaPlugin {
 
     private static FineHarvest plugin;
-    public static YamlConfiguration AureliumSources;
+    public static YamlConfiguration AuraSources;
 
     public static String tag = "[" + ChatColor.GOLD + "Fine" + ChatColor.DARK_GREEN + "Harvest" + ChatColor.RESET + "] ";
 
     // Lookup table for skill plugins
     public static Map<String, Boolean> skillMods = new HashMap<>() {{
         put("mcMMO", false);
-        put("AureliumSkills", false);
+        put("AuraSkills", false);
     }};
 
     @Override
@@ -50,17 +49,17 @@ public final class FineHarvest extends JavaPlugin {
                 getServer().getConsoleSender().sendMessage(tag + "Ignoring mcMMO as it was disabled by config!");
             }
         }
-        //Check for Aurelium
-        if (BuildCheck.hasPlugin("AureliumSkills")) {
-            skillMods.put("AureliumSkills", true);
+        //Check for AuraSkills
+        if (BuildCheck.hasPlugin("AuraSkills")) {
+            skillMods.put("AuraSkills", true);
             if(aureliumSkillsSupport) {
-                getServer().getConsoleSender().sendMessage(tag + ChatColor.GREEN + "AureliumSkills support enabled");
+                getServer().getConsoleSender().sendMessage(tag + ChatColor.GREEN + "AuraSkills support enabled");
             }else{
-                getServer().getConsoleSender().sendMessage(tag + "Ignoring AureliumSkills as it was disabled by config!");
+                getServer().getConsoleSender().sendMessage(tag + "Ignoring AuraSkills as it was disabled by config!");
             }
 
-            File file = new File("plugins/AureliumSkills/sources_config.yml");
-            AureliumSources = YamlConfiguration.loadConfiguration(file);
+            File file = new File("plugins/AuraSkills/sources/farming.yml");
+            AuraSources = YamlConfiguration.loadConfiguration(file);
         }
 
         //bStats init
@@ -94,8 +93,8 @@ public final class FineHarvest extends JavaPlugin {
     public static FineHarvest getPlugin() {
         return plugin;
     }
-    public static YamlConfiguration getAureliumSources() {
-        return AureliumSources;
+    public static YamlConfiguration getAuraSources() {
+        return AuraSources;
     }
 
 

--- a/src/main/java/org/finetree/fineharvest/protection/SuperiorSkyblock2.java
+++ b/src/main/java/org/finetree/fineharvest/protection/SuperiorSkyblock2.java
@@ -1,0 +1,18 @@
+package org.finetree.fineharvest.protection;
+
+import com.bgsoftware.superiorskyblock.api.SuperiorSkyblockAPI;
+import com.bgsoftware.superiorskyblock.api.island.Island;
+import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+
+public class SuperiorSkyblock2 {
+
+    public static boolean canSuperiorSkyblock2(Player ply, Block b) {
+        SuperiorPlayer sp = SuperiorSkyblockAPI.getPlayer(ply.getUniqueId());
+        Island island = SuperiorSkyblockAPI.getIslandAt(b.getLocation());
+        //ply.sendMessage("SuperiorSkyBlock2 Allowed");
+        return island.isMember(sp) || sp.hasBypassModeEnabled();
+    }
+
+}

--- a/src/main/java/org/finetree/fineharvest/protection/SuperiorSkyblock2.java
+++ b/src/main/java/org/finetree/fineharvest/protection/SuperiorSkyblock2.java
@@ -12,7 +12,10 @@ public class SuperiorSkyblock2 {
         SuperiorPlayer sp = SuperiorSkyblockAPI.getPlayer(ply.getUniqueId());
         Island island = SuperiorSkyblockAPI.getIslandAt(b.getLocation());
         //ply.sendMessage("SuperiorSkyBlock2 Allowed");
-        return island.isMember(sp) || sp.hasBypassModeEnabled();
+        if (sp != null && island != null) {
+            return island.isMember(sp) || sp.hasBypassModeEnabled();
+        }
+        return false;
     }
 
 }

--- a/src/main/java/org/finetree/fineharvest/skills/AureliumSkills.java
+++ b/src/main/java/org/finetree/fineharvest/skills/AureliumSkills.java
@@ -1,16 +1,17 @@
 package org.finetree.fineharvest.skills;
 
-import com.archyx.aureliumskills.skills.Skills;
+import dev.aurelium.auraskills.api.AuraSkillsApi;
+import dev.aurelium.auraskills.api.skill.Skills;
+import org.finetree.fineharvest.BuildCheck;
 import org.finetree.fineharvest.FineHarvest;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 
-import static com.archyx.aureliumskills.api.AureliumAPI.addXp;
-
 public class AureliumSkills {
 
     public static void aureliumAddXP(Player ply, Material mat) {
-        addXp(ply, Skills.FARMING, FineHarvest.getAureliumSources().getDouble("sources.farming." + mat.toString().toLowerCase()));
+            AuraSkillsApi.get().getUser(ply.getUniqueId()).addSkillXp(Skills.FARMING,
+                    FineHarvest.getAuraSources().getDouble("sources." + mat.toString().toLowerCase() + ".xp"));
     }
 
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ api-version: 1.21
 authors: [ Steampunk_Sam ]
 description: Allows auto-plant harvesting with Hoes
 website: finetree.org
-softdepend: [ mcMMO, AureliumSkills, GriefPrevention, Lands, WorldGuard, Towny, ProtectionStones, PlotSquared, GriefDefender, EssentialsAntiBuild, Essentials ]
+softdepend: [ mcMMO, AuraSkills, GriefPrevention, Lands, WorldGuard, Towny, ProtectionStones, PlotSquared, GriefDefender, EssentialsAntiBuild, Essentials, SuperiorSkyBlock2 ]
 permissions:
   fineharvest.use:
     description: Allows use of FineHarvest


### PR DESCRIPTION
Fix detecting AureliumSkills instead of the new named AuraSkills. Added support for checking SuperiorSkyblock2 protection.

This fixed AuraSkills not being detected, making the plugin work properly with AuraSkills, because AureliumSkills changed it's name.

I've tested the SuperiorSkyblock2 Protection and it does indeed work.

I kept the aureliumSkillsSupport config section the same to not disrupt the config files for any current installs.

This change will disrupt servers with old installations of AureliumSkills, but imo we should always be supporting the latest version of plugins.