### PR TITLE
feat: add support to copper hoe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ repositories {
 
 dependencies {
     implementation 'com.github.Redempt:RedLib:6.5.2.1'
-    compileOnly 'org.spigotmc:spigot-api:1.21.7-R0.1-SNAPSHOT'
+    compileOnly 'org.spigotmc:spigot-api:1.21.10-R0.1-SNAPSHOT'
     compileOnly 'com.gmail.nossr50.mcMMO:mcMMO:2.1.225' exclude group: 'commons-io'
     compileOnly 'com.github.Archy-X:AureliumSkills:Beta1.3.23'
     compileOnly 'com.github.TechFortress:GriefPrevention:16.18'

--- a/src/main/java/org/finetree/fineharvest/Events.java
+++ b/src/main/java/org/finetree/fineharvest/Events.java
@@ -132,7 +132,7 @@ public class Events implements Listener  {
 
     private boolean isHoe(Material material) {
         return switch (material) {
-            case WOODEN_HOE, STONE_HOE, IRON_HOE, GOLDEN_HOE, DIAMOND_HOE, NETHERITE_HOE -> true;
+            case WOODEN_HOE, STONE_HOE, COPPER_HOE, IRON_HOE, GOLDEN_HOE, DIAMOND_HOE, NETHERITE_HOE -> true;
             default -> false;
         };
     }


### PR DESCRIPTION
This PR adds support for the Copper Hoe, added to the game in the latest Minecraft update.

For it to work, it was needed to increase Spigot's API version from 1.21.7 to 1.21.10.

We also could, instead of checking from the Material enum, just check the material name to keep retro compatibility.