### PR TITLE
Allow harvesting on unclaimed GriefPrevention land and add unit test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,8 @@ repositories {
 }
 
 dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.12.2'
+
     implementation ('com.github.Redempt:RedLib:6.5.2.1') {
         exclude group: 'org.spigotmc', module: 'spigot-api'
         exclude group: 'org.bukkit', module: 'bukkit'
@@ -153,6 +155,10 @@ tasks.withType(JavaCompile).configureEach {
 
 tasks.withType(Javadoc).configureEach {
     options.encoding = 'UTF-8'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 processResources {

--- a/src/main/java/org/finetree/fineharvest/BuildCheck.java
+++ b/src/main/java/org/finetree/fineharvest/BuildCheck.java
@@ -29,7 +29,7 @@ public class BuildCheck {
         if(hasPlugin("Lands")){
             return canLands(ply, b);
         }
-        if(hasPlugin("griefPrevention")) {
+        if(hasPlugin("GriefPrevention")) {
             return canGriefPrev(ply, b);
         }
         if(hasPlugin("ProtectionStones")){

--- a/src/main/java/org/finetree/fineharvest/protection/GriefPrevention.java
+++ b/src/main/java/org/finetree/fineharvest/protection/GriefPrevention.java
@@ -9,10 +9,11 @@ public class GriefPrevention {
 
     public static boolean canGriefPrev(Player ply, Block b){
         Claim claim = me.ryanhamshire.GriefPrevention.GriefPrevention.instance.dataStore.getClaimAt(b.getLocation(), true, null);
-        if (claim != null) {
-            return claim.checkPermission(ply.getUniqueId(), ClaimPermission.Build, null) == null;
-        }
-        return false;
+        return canBuild(ply, claim);
+    }
+
+    static boolean canBuild(Player player, Claim claim) {
+        return claim == null || claim.checkPermission(player.getUniqueId(), ClaimPermission.Build, null) == null;
     }
 
 }

--- a/src/test/java/org/finetree/fineharvest/protection/GriefPreventionTest.java
+++ b/src/test/java/org/finetree/fineharvest/protection/GriefPreventionTest.java
@@ -1,0 +1,13 @@
+package org.finetree.fineharvest.protection;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GriefPreventionTest {
+
+    @Test
+    void allowsBuildingOutsideClaims() {
+        assertTrue(GriefPrevention.canBuild(null, null));
+    }
+}


### PR DESCRIPTION
### Motivation

- Fix a bug where harvesting was blocked on unclaimed territory when using GriefPrevention by correcting the claim-check logic and plugin lookup.
- Add a small unit test and test configuration to prevent regressions around GriefPrevention behavior.

### Description

- Update `GriefPrevention.canGriefPrev` to return true when the target block is outside any claim by delegating to a new helper `canBuild(Claim)` that treats `null` claims as allowed and preserves `ClaimPermission.Build` checks inside claims.
- Fix the plugin name lookup in `BuildCheck.canBuild` from `"griefPrevention"` to the correct `"GriefPrevention"` so the integration is detected reliably at runtime.
- Add JUnit support to `build.gradle` with `testImplementation 'org.junit.jupiter:junit-jupiter:5.12.2'` and enable the JUnit platform with a `test { useJUnitPlatform() }` task configuration.
- Add `src/test/java/org/finetree/fineharvest/protection/GriefPreventionTest.java` with a basic test `allowsBuildingOutsideClaims` that asserts `GriefPrevention.canBuild(null, null)` returns true.

### Testing

- Ran `git diff --check` and repository checks which passed and changes were committed successfully.
- Ran `./gradlew clean test` with the default environment which failed due to an incompatible JDK classfile error (original JVM was Java 25 causing "Unsupported class file major version 69").
- Re-ran `./gradlew clean test` under `JAVA_HOME` pointing to Java 21 which started Gradle but ultimately the build failed because the Gradle plugin artifact `com.gradleup.shadow:9.2.2` could not be resolved from the configured plugin repositories, preventing test execution.
- The added unit test and Gradle test configuration are present and ready; test execution should succeed once the build environment can resolve the shadow plugin or the buildscript is adjusted to run tests in CI with appropriate Java and plugin availability.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ed93ea8c48328a1f9ec1487bcdd89)