### PR TITLE
Add Quests farming progress support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Auto replants harvested crops.
 
 Has options for drop rates, sounds, durability mechanics, and more!
 
+FineHarvest also integrates with Quests so right-click crop harvests progress
+farming quest objectives just like normal crop breaks.
+
 *Works on all 1.14+ versions out of the box!*
 
 ![image](https://github.com/sammyt291/FineHarvest/assets/5092626/bf70fa35-1a1f-402b-834f-ce75c6709f9f)

--- a/src/main/java/org/finetree/fineharvest/BuildCheck.java
+++ b/src/main/java/org/finetree/fineharvest/BuildCheck.java
@@ -22,30 +22,41 @@ import static org.bukkit.Bukkit.getServer;
 
 public class BuildCheck {
 
+    /**
+     * The result of a build check. Some fallback checks publish a
+     * {@link BlockBreakEvent}; integrations must know this so they do not
+     * publish the same harvest twice.
+     */
+    public record BuildResult(boolean allowed, boolean blockBreakEventFired) {}
+
     public static boolean canBuild(Player ply, Block b) {
+        return checkBuild(ply, b).allowed();
+    }
+
+    public static BuildResult checkBuild(Player ply, Block b) {
         if(hasPlugin("Towny")) {
-            return canTowny(ply, b);
+            return new BuildResult(canTowny(ply, b), false);
         }
         if(hasPlugin("Lands")){
-            return canLands(ply, b);
+            return new BuildResult(canLands(ply, b), false);
         }
         if(hasPlugin("GriefPrevention")) {
-            return canGriefPrev(ply, b);
+            return new BuildResult(canGriefPrev(ply, b), false);
         }
         if(hasPlugin("ProtectionStones")){
             if(ProtStones.canProtectionStones(ply, b)){//Skip protectionstones check if no region, leave it up to WG global regions.
-                return true;
+                return new BuildResult(true, false);
             }
         }
         if(hasPlugin("PlotSquared")){
-            return Plot2.canPlotSquared(ply, b);
+            return new BuildResult(Plot2.canPlotSquared(ply, b), false);
         }
         if(hasPlugin("GriefDefender")){
-            return GriefDef.canGriefDefender(ply, b);
+            return new BuildResult(GriefDef.canGriefDefender(ply, b), false);
         }
         if (hasPlugin("SuperiorSkyblock2")) {
             if (SuperiorSkyblock2.canSuperiorSkyblock2(ply, b)) {//Skip SuperSkyblock2 check if no island, leave it up to WG global regions.
-                return true;
+                return new BuildResult(true, false);
             }
         }
         /*if(hasPlugin("Residence")) {
@@ -53,11 +64,11 @@ public class BuildCheck {
             return rPlayer.canBreakBlock(b, true);
         }*/
         if(hasPlugin("WorldGuard")) {
-            return canWorldGuard(ply, b);
+            return new BuildResult(canWorldGuard(ply, b), false);
         }
         //Check for both, as people be silly.
         if(hasPlugin("EssentialsAntiBuild") && hasPlugin("Essentials")){
-            return canEssentialsAntiBuild(ply, b);
+            return new BuildResult(canEssentialsAntiBuild(ply, b), false);
         }
 
         warnNoProtection();
@@ -65,7 +76,7 @@ public class BuildCheck {
         //Player can BlockBreak at this location?
         BlockBreakEvent e = new BlockBreakEvent(b, ply);
         FineHarvest.getPlugin().getServer().getPluginManager().callEvent(e);
-        return !e.isCancelled();
+        return new BuildResult(!e.isCancelled(), true);
     }
 
     public static boolean hasPlugin(String plugin){

--- a/src/main/java/org/finetree/fineharvest/Events.java
+++ b/src/main/java/org/finetree/fineharvest/Events.java
@@ -19,6 +19,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.Plugin;
+import org.finetree.fineharvest.quests.Quests;
 import org.finetree.fineharvest.skills.AureliumSkills;
 import org.finetree.fineharvest.skills.mcMMO;
 
@@ -84,9 +85,6 @@ public class Events implements Listener  {
         Block clickedBlock = e.getClickedBlock();
         if(clickedBlock == null){ return; }
 
-        //Check supported plugins if we can build here
-        if(!BuildCheck.canBuild(ply, clickedBlock)){ return; }
-
         //Check its a crop we clicked?
         Material mat = clickedBlock.getType();
         if (!isCrop(mat)) { return; }
@@ -94,6 +92,17 @@ public class Events implements Listener  {
         //Check the crop is ripe
         Ageable age = (Ageable) clickedBlock.getBlockData();
         if(!isSniffer(mat) && !isRipe(mat, age.getAge())) { return; }
+
+        //Check supported plugins if we can build here
+        BuildCheck.BuildResult buildResult = BuildCheck.checkBuild(ply, clickedBlock);
+        if(!buildResult.allowed()){ return; }
+
+        // Quests farming objectives listen for a normal crop break. The
+        // fallback build check already fires one, so never publish it twice.
+        if(BuildCheck.hasPlugin("Quests") && !buildResult.blockBreakEventFired()
+                && !Quests.publishHarvest(ply, clickedBlock)) {
+            return;
+        }
 
         Sounds.popSound(clickedBlock, harvestVolume);
 

--- a/src/main/java/org/finetree/fineharvest/quests/Quests.java
+++ b/src/main/java/org/finetree/fineharvest/quests/Quests.java
@@ -1,0 +1,25 @@
+package org.finetree.fineharvest.quests;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.finetree.fineharvest.FineHarvest;
+
+/**
+ * Compatibility bridge for the Quests farming quest type.
+ *
+ * <p>FineHarvest replaces a normal crop break with an in-place harvest, so
+ * Quests never sees the Bukkit event it uses to progress farming objectives.
+ * Publishing the equivalent event lets Quests process the harvest through its
+ * supported listener path.</p>
+ */
+public final class Quests {
+
+    private Quests() {}
+
+    public static boolean publishHarvest(Player player, Block crop) {
+        BlockBreakEvent event = new BlockBreakEvent(crop, player);
+        FineHarvest.getPlugin().getServer().getPluginManager().callEvent(event);
+        return !event.isCancelled();
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ folia-supported: true
 authors: [ Steampunk_Sam ]
 description: Allows auto-plant harvesting with Hoes
 website: finetree.org
-softdepend: [ mcMMO, AuraSkills, GriefPrevention, Lands, WorldGuard, Towny, ProtectionStones, PlotSquared, GriefDefender, EssentialsAntiBuild, Essentials, SuperiorSkyBlock2 ]
+softdepend: [ mcMMO, AuraSkills, Quests, GriefPrevention, Lands, WorldGuard, Towny, ProtectionStones, PlotSquared, GriefDefender, EssentialsAntiBuild, Essentials, SuperiorSkyBlock2 ]
 permissions:
   fineharvest.use:
     description: Allows use of FineHarvest


### PR DESCRIPTION
### Motivation

- Allow Quests farming-type objectives to progress when FineHarvest performs a right-click harvest, since FineHarvest restores crops in-place and Quests normally listens for `BlockBreakEvent`.
- Avoid double-publishing a block-break-style event when existing fallback checks already fire one.

### Description

- Added a Quests compatibility bridge `org.finetree.fineharvest.quests.Quests` with `publishHarvest` which publishes a `BlockBreakEvent` for Quests to consume (`src/main/java/org/finetree/fineharvest/quests/Quests.java`).
- Extended build checks by introducing `BuildResult` and `checkBuild` in `BuildCheck` so callers can learn if the fallback published a `BlockBreakEvent` (`src/main/java/org/finetree/fineharvest/BuildCheck.java`).
- Modified the crop interaction flow in `Events` to call `checkBuild`, to publish the Quests-compatible harvest only when Quests is present and no prior `BlockBreakEvent` was fired, and to abort if the published event is cancelled (`src/main/java/org/finetree/fineharvest/Events.java`).
- Declared `Quests` as a soft dependency in `plugin.yml` and updated `README.md` to document Quests integration (`src/main/resources/plugin.yml`, `README.md`).

### Testing

- Ran `git diff --check` and staged/committed the changes successfully. ✔️
- Attempted to run the Gradle test/build (`./gradlew clean test`) but the build failed due to environment limitations (dependency/plugin resolution and Java/Gradle compatibility issues), so unit tests could not be executed in this environment. ❌
- Verified repository status with `git status --short` and inspected the modified files to confirm the intended edits were applied. ✔️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8edc16ba608328a74e320ff9b01a75)